### PR TITLE
fix: Add CSRF Token to index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ yarn
 yarn dev
 ```
 
+In a development environment, you need to put the below key-value pair in your `site_config.json` file:
+
+```
+"ignore_csrf": 1
+```
+
+This will prevent `CSRFToken` errors while using the vite dev server. In production environment, the `csrf_token` is attached to the `window` object in `index.html` for you.
+
 The Vite dev server will start on the port `8080`. This can be changed from `vite.config.js`.
 The development server is configured to proxy your frappe app (usually running on port `8000`). If you have a site named `todo.test`, open `http://todo.test:8080` in your browser. If you see a button named "Click to send 'ping' request", congratulations!
 
@@ -26,6 +34,7 @@ If you notice the browser URL is `/frontend`, this is the base URL where your fr
 To change this, open `src/router.js` and change the base URL passed to `createWebHistory`.
 
 ## Resources
+
 - [Vue 3](https://v3.vuejs.org/guide/introduction.html)
 - [Vue Router](https://next.router.vuejs.org/guide/)
 - [Frappe UI](https://github.com/frappe/frappe-ui)

--- a/index.html
+++ b/index.html
@@ -10,6 +10,8 @@
     <div id="app"></div>
     <div id="modals"></div>
     <div id="popovers"></div>
+
+    <script> window.csrf_token = '{{ csrf_token }}'; </script>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
**Problem**: CSRFToken Error

![photo_2022-01-18 17 21 06](https://user-images.githubusercontent.com/34810212/149932409-e887cd8a-fc0a-476b-a1e4-21225199fd6c.jpeg)
 
But this only solves the issue in production, for dev environment, the solution is to add `"ignore_csrf": 1` in `site_config.json`. Maybe we should mention that in README @netchampfaris ?